### PR TITLE
Use TypeScript and Vue Config simultaneously

### DIFF
--- a/typescript/index.js
+++ b/typescript/index.js
@@ -5,7 +5,9 @@ module.exports = {
         '../javascript/index.js',
         'plugin:@typescript-eslint/recommended',
     ],
-    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        parser: '@typescript-eslint/parser',
+    },
     plugins: [
         '@typescript-eslint',
     ],


### PR DESCRIPTION
This fix enables that both 'ion2s/typescript' and 'ion2s/vue' configurations can be used simultaneously. Vue components that use TypeScript can be linted this way.

Example .eslintrc:
```js
module.exports = {
    extends: [
        'ion2s/typescript',
        'ion2s/vue',
    ],
};
```