### PR TITLE
Add rule to allow usage of function before definition

### DIFF
--- a/typescript/index.js
+++ b/typescript/index.js
@@ -24,6 +24,7 @@ module.exports = {
         }],
         '@typescript-eslint/explicit-member-accessibility': ['error'],
         '@typescript-eslint/member-ordering': ['error'],
+        '@typescript-eslint/no-use-before-define': ['error', 'nofunc'],
     },
     overrides: [
         {


### PR DESCRIPTION
@orkanone kannst du bitte dir den Commit anschauen, ob das für dich okay ist. Ich würde gerne Funktionen benutzen, bevor diese deklariert sind. Siehe auch https://eslint.org/docs/rules/no-use-before-define